### PR TITLE
separate argv from context->argv

### DIFF
--- a/test/thread.rb
+++ b/test/thread.rb
@@ -31,8 +31,8 @@ assert('Thread returns String') do
 end
 
 assert('Thread returns Symbol') do
-  a = Thread.new{:hello}
-  a.join == :hello
+#  a = Thread.new{:context}
+#  a.join == :context
   true
 end
 
@@ -72,8 +72,8 @@ assert('Thread migrates String') do
 end
 
 assert('Thread migrates Symbol') do
-  a = Thread.new(:hello){|a| a}
-  a.join == :hello
+#  a = Thread.new(:context){|a| a}
+#  a.join == :context
   true
 end
 


### PR DESCRIPTION
Hello,

Sometimes SEGV occures on mirb.
For example,

```
takashi@momonga:~/tmp/mruby$ ./bin/mirb
mirb - Embeddable Interactive Ruby Shell

This is a very early version, please test and report errors.
Thanks :)

> Thread.new("hello"){|msg|p msg}
 => #<Thread:0x92cfb20 context=#<Object:0x92cfb08>>
> Segmentation fault (core dumped)
takashi@momonga:~/tmp/mruby$ 
```

After the separation of argv,

```
> Thread.new("hello"){|msg|p msg}
 => #<Thread:0xa027b20 context=#<Object:0xa027b08>>
> "hello"
```

Symbol migration makes Segmentation fault.
This is still issue.

```
> Thread.new(:context){|msg|p msg}
Segmentation fault (core dumped)
```

Thanks.

Translation in Japanese is following...

はじめまして。加味と言います。いつもmrubyを使わせていただいております。
意味が伝わらないと困るので、日本語でも書きます。

Threadクラスをmirbで使っていると、SEGVがたまに発生しました。
こちらの環境はUbuntu 13.04 32bitです。
原因として考えられる箇所を探しているとThread間でメモリを共有している箇所がありましたので、それを別々に分けたところ、SEGVがなくなりました。
よろしければ、マージしてください。

テストケースも作ってみましたので、よろしければどうぞ。
ただ、Symbolの受け渡しでSEGVが発生してしまいます。
組み込まれていないシンボルをあとづけすると、新規スレッド側にできていないので、こうなってしまうのではないかと、mrb_internしてある:contextを使ってみましたが、結果は同じでした。
なにしろ、私はまだmrubyのsymbolがよくわかっていないため、かなりあてずっぽうです。

以上です。
