### PR TITLE
create a closure instead of a proc

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -111,7 +111,7 @@ static void*
 mrb_thread_func(void* data) {
   mrb_thread_context* context = (mrb_thread_context*) data;
   mrb_state* mrb = context->mrb;
-  struct RProc* np = mrb_proc_new(mrb, context->proc->body.irep);
+  struct RProc* np = mrb_closure_new(mrb, context->proc->body.irep);
   context->result = mrb_yield_argv(mrb, mrb_obj_value(np), context->argc, context->argv);
   return NULL;
 }


### PR DESCRIPTION
This small change was all that was need to have the tests pass with the most current mruby source. The mrb_proc_new function still exists, so the mrb_closure_new is doing more than this function. So I am not sure this is right.
