### PR TITLE
Trying to solve crash in mob_thread_func

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -112,7 +112,7 @@ mrb_thread_func(void* data) {
   mrb_thread_context* context = (mrb_thread_context*) data;
   mrb_state* mrb = context->mrb;
   struct RProc* np = mrb_proc_new(mrb, context->proc->body.irep);
-  context->result = mrb_yield_argv(mrb, mrb_obj_value(np), context->argc, context->argv);
+  context->result = mrb_yield_argv(mrb, mrb_obj_value(context->proc), context->argc, context->argv);
   return NULL;
 }
 


### PR DESCRIPTION
It was related to a null np➜env.

Should close #2 and #3
