### PR TITLE
Require unistd.h for sleep(3)

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -13,6 +13,7 @@
 #include <windows.h>
 #endif
 #include <ctype.h>
+#include <unistd.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
On RedHat/Fedora sleep(3) is defined in unistd.h.
