### PR TITLE
Require signal.h for pthread_kill(3)

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -16,6 +16,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
On Debian/RedHat pthread_kill is defined in signal.h.
