### PR TITLE
Android doesn't have pthreads lib, it uses a flag.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,5 +2,9 @@ MRuby::Gem::Specification.new('mruby-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
 
-  spec.linker.libraries << ['pthread']
+  if build.toolchains.include?("androideabi")
+    spec.cc.flags << '-DHAVE_PTHREADS'
+  else
+    spec.linker.libraries << ['pthread']
+  end
 end


### PR DESCRIPTION
Adding the -lpthreads flag when building with the android toolchain throws an error that the pthreads lib can't be found. Instead, it needs a `-DHAVE_PTHREADS` flag.
