### PR TITLE
Change mrb_get_args argc type to mrb_int

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -164,7 +164,7 @@ mrb_thread_func(void* data) {
 static mrb_value
 mrb_thread_init(mrb_state* mrb, mrb_value self) {
   mrb_value proc = mrb_nil_value();
-  int argc;
+  mrb_int argc;
   mrb_value* argv;
   mrb_get_args(mrb, "&*", &proc, &argv, &argc);
   if (!mrb_nil_p(proc)) {


### PR DESCRIPTION
Test crashes if defined MRB_INT64.
This issue is same as https://github.com/mattn/mruby-sqlite3/issues/7
