### PR TITLE
define _TIMESPEC_DEFINED to avoid compilation errors on windows

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -15,6 +15,7 @@
 #endif
 #ifdef _WIN32
 #include <windows.h>
+#define _TIMESPEC_DEFINED
 #endif
 #include <ctype.h>
 #include <pthread.h>


### PR DESCRIPTION
the line #define _TIMESPEC_DEFINED will prevent the library pthreads-win32 to redefine struct timespec and avoid compilation errors on windows