### PR TITLE
Sharing instances between threads

### DIFF
--- a/example/data.rb
+++ b/example/data.rb
@@ -8,16 +8,19 @@ end
 
 $mutex = Mutex.new
 $queue = MyContainer.new(1)
+$ary = []
 
-svr = Thread.new($queue, $mutex) do |q, m|
+svr = Thread.new($queue, $mutex, $ary) do |q, m, a|
   20.times do |i|
     q.data = q.data + 1
-    Thread.sleep 1
+    a << q.data
+    a.shift if a.size > 3
+    Thread.sleep 2
   end
 end
 
 while true do
-  puts "count = #{$queue.data}"
+  puts "count = #{$queue.data}, ary = #{$ary}"
   if $queue.data > 10 then
     svr.kill
     break

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,7 +1,10 @@
 MRuby::Gem::Specification.new('mruby-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
-
+  
+  # Uncomment for copying instances on Thread::new()
+  # spec.cc.flags << "-DMRB_THREAD_COPY_VALUES"
+  
   if build.toolchains.include?("androideabi")
     spec.cc.flags << '-DHAVE_PTHREADS'
   else


### PR DESCRIPTION
This tries to share instances between threads.

I am still not 100% sure that this PR is not causing any detrimental side-effect, and for this reason in mrbgem.rake I added the compilation flag `MRB_THREAD_COPY_VALUES` that, when enabled, makes the implementation of `Thread::new()` to make a copy of passed instances rather than linking to them.