### PR TITLE
Fix symbol initialization issue

### DIFF
--- a/src/mrb_init_functions.h
+++ b/src/mrb_init_functions.h
@@ -1,0 +1,21 @@
+void mrb_init_symtbl(mrb_state *);
+void mrb_init_class(mrb_state *);
+void mrb_init_object(mrb_state *);
+void mrb_init_kernel(mrb_state *);
+void mrb_init_comparable(mrb_state *);
+void mrb_init_enumerable(mrb_state *);
+void mrb_init_symbol(mrb_state *);
+void mrb_init_exception(mrb_state *);
+void mrb_init_proc(mrb_state *);
+void mrb_init_string(mrb_state *);
+void mrb_init_array(mrb_state *);
+void mrb_init_hash(mrb_state *);
+void mrb_init_numeric(mrb_state *);
+void mrb_init_range(mrb_state *);
+void mrb_init_gc(mrb_state *);
+void mrb_init_math(mrb_state *);
+void mrb_init_version(mrb_state *);
+void mrb_init_mrblib(mrb_state *);
+
+void mrb_init_mrbgems(mrb_state *);
+void mrb_gc_init(mrb_state *, mrb_gc *gc);

--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -334,6 +334,61 @@ mrb_thread_func(void* data) {
   return NULL;
 }
 
+#include "mrb_init_functions.h"
+#define DONE mrb_gc_arena_restore(mrb, 0);
+
+/* Base from mrb_open_core in state.c */
+static mrb_state*
+mrb_symbol_safe_copy(mrb_state *mrb_src) {
+  static const mrb_state mrb_state_zero = {0};
+  static const struct mrb_context mrb_context_zero = {0};
+  mrb_state *mrb;
+  mrb_allocf f = mrb_src->allocf;
+  void *ud = mrb_src->allocf_ud;
+
+  mrb = (mrb_state *)(f)(NULL, NULL, sizeof(mrb_state), ud);
+  if (mrb == NULL) return NULL;
+
+  *mrb = mrb_state_zero;
+  mrb->allocf_ud = ud;
+  mrb->allocf = f;
+  mrb->atexit_stack_len = 0;
+
+  mrb_gc_init(mrb, &mrb->gc);
+  mrb->c = (struct mrb_context *)mrb_malloc(mrb, sizeof(struct mrb_context));
+  *mrb->c = mrb_context_zero;
+  mrb->root_c = mrb->c;
+
+  /* As mrb_init_core do but copy symbols before library initialization */
+  mrb_init_symtbl(mrb); DONE;
+
+  migrate_all_symbols(mrb_src, mrb); DONE;
+
+  mrb_init_class(mrb); DONE;
+  mrb_init_object(mrb); DONE;
+  mrb_init_kernel(mrb); DONE;
+  mrb_init_comparable(mrb); DONE;
+  mrb_init_enumerable(mrb); DONE;
+
+  mrb_init_symbol(mrb); DONE;
+  mrb_init_exception(mrb); DONE;
+  mrb_init_proc(mrb); DONE;
+  mrb_init_string(mrb); DONE;
+  mrb_init_array(mrb); DONE;
+  mrb_init_hash(mrb); DONE;
+  mrb_init_numeric(mrb); DONE;
+  mrb_init_range(mrb); DONE;
+  mrb_init_gc(mrb); DONE;
+  mrb_init_version(mrb); DONE;
+  mrb_init_mrblib(mrb); DONE;
+
+#ifndef DISABLE_GEMS
+  mrb_init_mrbgems(mrb); DONE;
+#endif
+
+  return mrb;
+}
+
 static mrb_value
 mrb_thread_init(mrb_state* mrb, mrb_value self) {
   mrb_value proc = mrb_nil_value();
@@ -347,8 +402,8 @@ mrb_thread_init(mrb_state* mrb, mrb_value self) {
     int i, l;
     mrb_thread_context* context = (mrb_thread_context*) malloc(sizeof(mrb_thread_context));
     context->mrb_caller = mrb;
-    context->mrb = mrb_open_allocf(mrb->allocf, mrb->allocf_ud);
-    migrate_all_symbols(mrb, context->mrb);
+    mrb_state* mrb2 = mrb_symbol_safe_copy(mrb);
+    context->mrb = mrb2;
     context->proc = mrb_proc_new(mrb, mrb_proc_ptr(proc)->body.irep);
     context->proc->target_class = context->mrb->object_class;
     context->argc = argc;

--- a/test/thread.rb
+++ b/test/thread.rb
@@ -31,9 +31,8 @@ assert('Thread returns String') do
 end
 
 assert('Thread returns Symbol') do
-#  a = Thread.new{:context}
-#  a.join == :context
-  true
+  a = Thread.new{:context}
+  assert_true a.join == :context
 end
 
 assert('Thread returns Array') do
@@ -72,9 +71,8 @@ assert('Thread migrates String') do
 end
 
 assert('Thread migrates Symbol') do
-#  a = Thread.new(:context){|a| a}
-#  a.join == :context
-  true
+  a = Thread.new(:context){|a| a}
+  assert_true a.join == :context
 end
 
 assert('Thread migrates Array') do
@@ -94,4 +92,3 @@ assert('Thread migrates Proc') do
   a = Thread.new(pr){|pr| pr.call }
   a.join == 1
 end
-

--- a/test/thread.rb
+++ b/test/thread.rb
@@ -118,3 +118,10 @@ assert('Thread migrates Object') do
   assert_equal 123,      a.bar
   assert_equal :buz,     a.buz
 end
+
+assert('Fixed test of issue #36') do
+  a = Thread.new do
+    "".is_a?(String)
+  end
+  assert_true a.join
+end


### PR DESCRIPTION
Hi, I fixed the timing of symbol table copy.

I ran tests locally on Linux (Ubuntu Xenial, kernel 4.4.0-72-generic) with patch below:

```diff
diff --git a/test_build.rb b/test_build.rb
index b5feb8e..8c3044b 100755
--- a/test_build.rb
+++ b/test_build.rb
@@ -20,4 +20,7 @@ MRuby::Build.new do |conf|
   conf.linker.libraries << ['pthread']
   conf.gembox 'default'
   conf.gem File.dirname(__FILE__)
+
+  conf.cc.flags << "-DMRB_THREAD_COPY_VALUES"
+  conf.enable_test
 end
```

## This may fix...

* https://github.com/mattn/mruby-thread/issues/36
* https://github.com/mattn/mruby-thread/issues/42
