### PR TITLE
Guard thread killing when threads are marked as already dead

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -50,7 +50,7 @@ mrb_thread_context_free(mrb_state *mrb, void *p) {
   if (p) {
     mrb_thread_context* context = (mrb_thread_context*) p;
     if (context->mrb && context->mrb != mrb) mrb_close(context->mrb);
-    pthread_kill(context->thread, SIGINT);
+    if (context->alive) pthread_kill(context->thread, SIGINT);
     if (context->argv) free(context->argv);
     free(p);
   }
@@ -495,7 +495,7 @@ mrb_thread_kill(mrb_state* mrb, mrb_value self) {
   if (context->mrb == NULL) {
     return mrb_nil_value();
   }
-  pthread_kill(context->thread, SIGINT);
+  if(context->alive) pthread_kill(context->thread, SIGINT);
   mrb_close(context->mrb);
   context->mrb = NULL;
   return context->result;


### PR DESCRIPTION
`context->alive` seems to be marked FALSE in the end of `mrb_thread_func`.

https://github.com/mattn/mruby-thread/blob/master/src/mrb_thread.c#L362

So I guess only threads to invoke pthread_kill are `context->alive = TRUE` ones.

<details>
<summary>(BTW, this patch may fix this kind of segfault)</summary>

### before

```console
$ ./bin/mruby -e '10.times.map{ Thread.new { raise "Foo" } }.each_with_index{|t, i| t.join && puts("OK: #{i}") }'      
OK: 0
OK: 1
OK: 2
OK: 3
OK: 4
OK: 5
OK: 6
OK: 7
OK: 8
OK: 9
Segmentation fault (core dumped)
```

bt:

```
Thread 1 "mruby" received signal SIGSEGV, Segmentation fault.
__pthread_kill (threadid=140737219917568, signo=2) at ../sysdeps/unix/sysv/linux/pthread_kill.c:39
39      ../sysdeps/unix/sysv/linux/pthread_kill.c: No such file or directory.
(gdb) bt
#0  __pthread_kill (threadid=140737219917568, signo=2) at ../sysdeps/unix/sysv/linux/pthread_kill.c:39
#1  0x000000000046947d in mrb_thread_context_free (mrb=0x69f010, p=0x86aa20) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/src/mrb_thread.c:53
#2  0x0000000000410449 in obj_free (mrb=0x69f010, obj=0x6e6100, end=1) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/src/gc.c:809
#3  0x0000000000410528 in free_heap (gc=<optimized out>, mrb=<optimized out>) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/src/gc.c:385
#4  mrb_gc_destroy (mrb=<optimized out>, gc=<optimized out>) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/src/gc.c:394
#5  0x000000000041d402 in mrb_close (mrb=<optimized out>) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/src/state.c:253
#6  0x00000000004024b0 in cleanup (mrb=<optimized out>, args=<optimized out>)
    at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c:165
#7  main (argc=<optimized out>, argv=<optimized out>) at /Users/udzura/.ghq/github.com/mattn/mruby-thread/mruby_build/mrbgems/mruby-bin-mruby/tools/mruby/mruby.c:248
```

### after

```console
$ ./bin/mruby -e '10.times.map{ Thread.new { raise "Foo" } }.each_with_index{|t, i| t.join && puts("OK: #{i}") }'      
OK: 0
OK: 1
OK: 2
OK: 3
OK: 4
OK: 5
OK: 6
OK: 7
OK: 8
OK: 9
(exits 0)
```

tried on x86_64 Ubuntu Xenial, with gcc 5.4.0 20160609.

</details>
