### PR TITLE
Skip migration of REnv->mid

### DIFF
--- a/src/mrb_thread.c
+++ b/src/mrb_thread.c
@@ -240,7 +240,6 @@ struct RProc*
 migrate_rproc(mrb_state *mrb, struct RProc *rproc, mrb_state *mrb2) {
   struct RProc *newproc = mrb_closure_new(mrb2, migrate_irep(mrb, rproc->body.irep, mrb2));
   newproc->env = rproc->env;
-  newproc->env->mid = migrate_sym(mrb, rproc->env->mid, mrb2);
   return newproc;
 }
 


### PR DESCRIPTION
At mruby head, `struvt REnv` has been changed its format(then build failes), and this migration seems no effect(at least, all of test passes with COPY_VALUES)

I heard that `mid` is used for debug (in Japanese)

https://twitter.com/yukihiro_matz/status/857087036645408768