### PR TITLE
 Use -pthread flag and not -lpthread

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,7 +3,7 @@ MRuby::Gem::Specification.new('mruby-thread') do |spec|
   spec.authors = 'mattn'
 
   if build.toolchains.include?('androideabi')
-    spec.cc.flags << '-DHAVE_PTHREADS'
+    spec.cc.defines << 'HAVE_PTHREADS'
   else
     spec.linker.libraries << ['pthread']
   end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,11 +2,7 @@ MRuby::Gem::Specification.new('mruby-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
 
-  defs = %w[MRB_THREAD_COPY_VALUES]
-  build.cc.defines += defs
-  spec.cc.defines+= defs
-
-  if build.toolchains.include?("androideabi")
+  if build.toolchains.include?('androideabi')
     spec.cc.flags << '-DHAVE_PTHREADS'
   else
     spec.linker.libraries << ['pthread']

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,6 @@ MRuby::Gem::Specification.new('mruby-thread') do |spec|
   if build.toolchains.include?('androideabi')
     spec.cc.defines << 'HAVE_PTHREADS'
   else
-    spec.linker.libraries << ['pthread']
+    spec.linker.libraries << 'pthread'
   end
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,6 @@ MRuby::Gem::Specification.new('mruby-thread') do |spec|
   if build.toolchains.include?('androideabi')
     spec.cc.defines << 'HAVE_PTHREADS'
   else
-    spec.linker.libraries << 'pthread'
+    spec.linker.flags << '-pthread'
   end
 end


### PR DESCRIPTION
If you use pthreads, you must use the `-pthread` flag, not `-lpthread`. You should be doing this anyway, however, so you're probably fine. `-lpthread` just adds libpthread.so to your link flags, but the proper way is `-pthread`, which also defines the `_REENTRANT` flag, which lets the build know it's going to be linked to libpthread.so.